### PR TITLE
Removing unnecessary dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
   "author": "Alexander Prytula",
   "license": "ISC",
   "devDependencies": {
-    "mocha": "^3.5.0",
-    "joi": "^6.0.0",
-    "winston": "^2.0.0"
+    "mocha": "^3.5.0"
   }
 }


### PR DESCRIPTION
did not see if `joi`, `winston` used somewhere in code (even in tests)